### PR TITLE
feat(route): 라우트 가드 미들웨어 구현

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,18 @@
+import { NextResponse, NextRequest } from "next/server";
+import { guardRules } from "@/shared/proxy/proxy.guard";
+
+const proxy = (request: NextRequest) => {
+  const matchedRule = guardRules.find((rule) => rule.when(request));
+
+  if (matchedRule) {
+    return NextResponse.redirect(new URL(matchedRule.redirect, request.url));
+  }
+  return NextResponse.next();
+};
+
+export const config = {
+  matcher:
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+};
+
+export default proxy;

--- a/shared/proxy/proxy.guard.ts
+++ b/shared/proxy/proxy.guard.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { NextRequest } from "next/server";
+import { isGuestRoute, hasSession, isProtectedRoute } from "./proxy.utils";
+
+type GuardRule = {
+  when: (req: NextRequest) => boolean;
+  redirect: string;
+};
+
+export const guardRules: GuardRule[] = [
+  {
+    when: (req: NextRequest) => isGuestRoute(req) && hasSession(req),
+    redirect: "/",
+  },
+  {
+    when: (req: NextRequest) => isProtectedRoute(req) && !hasSession(req),
+    redirect: "/login",
+  },
+];

--- a/shared/proxy/proxy.utils.ts
+++ b/shared/proxy/proxy.utils.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { NextRequest } from "next/server";
+
+export const GUEST_ROUTES = ["/login", "/signup"] as const;
+
+export const isGuestRoute = (request: NextRequest) => {
+  const { pathname } = request.nextUrl;
+  return GUEST_ROUTES.some((route) => pathname.includes(route));
+};
+
+export const hasSession = (request: NextRequest) => {
+  const accessToken = request.cookies.get("accessToken");
+  return !!accessToken;
+};
+
+export const isProtectedRoute = (request: NextRequest) => {
+  return !isGuestRoute(request);
+};


### PR DESCRIPTION
# Pull Request

## 변경 사항

- Next.js 16의 proxy 기능을 활용한 라우트 가드 미들웨어 구현
  - 인증이 필요한 보호된 라우트 접근 시 `/login`으로 리다이렉트
  - 인증된 사용자의 게스트 라우트(`/login`, `/signup`) 접근 시 루트로 리다이렉트
  - `shared/proxy/` 디렉토리에 가드 규칙 및 유틸리티 함수 분리

## 변경 유형

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] 리팩토링 (Code refactoring)
- [x] 문서 업데이트 (Documentation update)
- [ ] 스타일 변경 (Style change)
- [ ] 테스트 추가/수정 (Test update)
- [x] 빌드/배포 관련 (Build/Deploy)

## 관련 이슈

<!-- 관련된 이슈가 있다면 연결해주세요 -->

Closes #(issue number)

## 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 추가 정보

- `proxy.ts`는 Next.js 16의 proxy 파일로, 기존 middleware.ts 대신 사용됩니다
- 라우트 가드 로직은 `shared/proxy/` 디렉토리에서 관리하며, 확장 가능한 구조로 설계했습니다
- 쿠키 기반 세션 확인(`accessToken`)을 통해 인증 상태를 판단합니다

