### PR TITLE
feat(signup): 회원가입시에도 토큰을 주입받는 패턴으로 로직 변경

### DIFF
--- a/domains/signup/api/signup.ts
+++ b/domains/signup/api/signup.ts
@@ -1,7 +1,25 @@
-import { SignupRequest, SignupResponse } from '@/domains/signup/types';
-import { apiClient } from '@/shared/api/api.client';
-import { ApiResponse } from '@/shared/api/api.types';
+'use server';
 
-export const postSignupRequest = async (data: SignupRequest) => {
-  await apiClient.post<ApiResponse<SignupResponse>>('/user/signup', data);
+import { SignupRequest } from '@/domains/signup/types';
+import { apiServerClient } from '@/shared/api/api.server-client';
+import { ApiError } from '@/shared/api/api.types';
+import { applySetCookieHeader } from '@/shared/utils';
+
+export const postSignup = async (
+  data: SignupRequest,
+): Promise<void | ApiError> => {
+  try {
+    const response = await apiServerClient.requestRaw('/user/signup', {
+      method: 'POST',
+      body: data,
+    });
+
+    const setCookieHeaders = response.headers['set-cookie'];
+
+    if (setCookieHeaders && Array.isArray(setCookieHeaders)) {
+      await applySetCookieHeader(setCookieHeaders);
+    }
+  } catch (error) {
+    return error as ApiError;
+  }
 };

--- a/domains/signup/hooks/use-signup-query.ts
+++ b/domains/signup/hooks/use-signup-query.ts
@@ -1,23 +1,21 @@
-import { useRouter } from 'next/navigation';
-
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { postSignupRequest } from '@/domains/signup/api';
+import { postSignup } from '@/domains/signup/api';
 import { SignupRequest } from '@/domains/signup/types';
 import { getUserApiErrorMessage } from '@/domains/user/utils';
 import { ApiError } from '@/shared/api/api.types';
 import { trackEvent } from '@/shared/lib/posthog';
 
 export const useSignup = () => {
-  const router = useRouter();
-
   return useMutation<void, ApiError, SignupRequest>({
-    mutationFn: (data: SignupRequest) => postSignupRequest(data),
+    mutationFn: async (data: SignupRequest) => {
+      const errorResult = await postSignup(data);
+      if (errorResult) throw errorResult;
+    },
     onSuccess: () => {
       trackEvent('signup_completed', { method: 'email' });
       toast.success('회원가입이 완료되었어요.');
-      router.push('/onboarding');
     },
     onError: (error) => {
       trackEvent('signup_failed', {

--- a/domains/signup/ui/signup-form.tsx
+++ b/domains/signup/ui/signup-form.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 
+import { useRouter } from 'next/navigation';
+
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
 
@@ -18,6 +20,8 @@ import PasswordConfirmField from './password-confirm-field';
 import PasswordField from './password-field';
 
 export default function SignupForm() {
+  const router = useRouter();
+
   const form = useForm<SignupFormValues>({
     resolver: zodResolver(signupFormSchema),
     mode: 'onChange',
@@ -26,7 +30,7 @@ export default function SignupForm() {
       password: '',
     },
   });
-  const { mutate: signup, isPending: isSignupPending } = useSignup();
+  const { mutateAsync: handleSignup, isPending: isSignupPending } = useSignup();
   const {
     startTimer: handleStartEmailCertificationTimer,
     endTimer: handleEndEmailCertificationTimer,
@@ -37,11 +41,12 @@ export default function SignupForm() {
   const submitDisabled = isSignupPending || !isPasswordConfirmed;
 
   const handleSubmit = useCallback(
-    (data: SignupFormValues) => {
+    async (data: SignupFormValues) => {
       if (submitDisabled) return;
-      signup(data);
+      await handleSignup(data);
+      router.replace('/onboarding');
     },
-    [submitDisabled, signup],
+    [submitDisabled, handleSignup, router],
   );
 
   const handleError = useCallback((errors: FieldErrors) => {


### PR DESCRIPTION
# Pull Request

## 변경 사항

as-is: 회원가입 완료 후 /login으로 진입하여 로그인을 진행하기에 /onboarding을 바로 진행할 수 없었음
to-be: 백엔드에서 email signup시에도 token을 전달하여, 로그인이 바로 되어 /onboarding으로 진입할 수 있도록 하였음

## 변경 유형

<!-- 해당하는 항목에 'x'를 표시해주세요 -->

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] 리팩토링 (Code refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 스타일 변경 (Style change)
- [ ] 테스트 추가/수정 (Test update)
- [ ] 빌드/배포 관련 (Build/Deploy)

## 관련 이슈

<!-- 관련된 이슈가 있다면 연결해주세요 -->

- Fixes Looppit/Looppit-Backend#95

## 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
